### PR TITLE
Ajout Ilevia (Lille)

### DIFF
--- a/input.yaml
+++ b/input.yaml
@@ -77,6 +77,9 @@ datasets:
   # Métropole Toulouse
   - slug: tisseo-offre-de-transport-gtfs
     prefix: fr-toulouse
+  # Métropole Européenne de Lille
+  - slug: localisation-des-arrets-ilevia-bus-metro-et-tram-gtfs-pictogrammes-du-reseau-ilevia-2
+    prefix: fr-lille
 
   # DATASETS PRIVÉS
   # SNCF


### PR DESCRIPTION
https://transport.data.gouv.fr/datasets/localisation-des-arrets-ilevia-bus-metro-et-tram-gtfs-pictogrammes-du-reseau-ilevia-2
Je n'ai pas testé cet ajout. Le fichier proposé semble être du GTFS-RT, je ne sais pas si cela est pris en charge?