### PR TITLE
Ajout réseau bus somme

### DIFF
--- a/input.yaml
+++ b/input.yaml
@@ -37,6 +37,8 @@ datasets:
   # Corse
   # Grand Est
   # Haut-de-France
+  - slug: arrets-horaires-et-parcours-theoriques-gtfs-du-reseau-routier-regional-de-transport-interurbain-80-somme
+    prefix: fr-hdf-somme
   # Ile-de-France
   - slug: reseau-urbain-et-interurbain-dile-de-france-mobilites
     prefix: fr-idf


### PR DESCRIPTION
Le réseau de bus de la somme. Les autres départements des HDF semblent avoir le même genre de GTFS, à ajouter si cela fonctionne.
PS : C'est mon premier commit sur cartes, y a-t-il des tests à faire pour valider le réseau ?